### PR TITLE
fix(cf-workers): add missing function

### DIFF
--- a/packages/cloudflare-workers/src/manager-driver.ts
+++ b/packages/cloudflare-workers/src/manager-driver.ts
@@ -6,6 +6,7 @@ import {
 	type GetForIdInput,
 	type GetOrCreateWithKeyInput,
 	type GetWithKeyInput,
+	generateRandomString,
 	type ManagerDisplayInformation,
 	type ManagerDriver,
 	WS_PROTOCOL_ACTOR,
@@ -371,5 +372,9 @@ export class CloudflareActorsManagerDriver implements ManagerDriver {
 			name: "Cloudflare Workers",
 			properties: {},
 		};
+	}
+
+	getOrCreateInspectorAccessToken() {
+		return generateRandomString();
 	}
 }

--- a/packages/rivetkit/src/driver-helpers/mod.ts
+++ b/packages/rivetkit/src/driver-helpers/mod.ts
@@ -1,5 +1,6 @@
 export type { ActorDriver } from "@/actor/driver";
 export type { ActorInstance, AnyActorInstance } from "@/actor/instance";
+export { generateRandomString } from "@/actor/utils";
 export {
 	ALLOWED_PUBLIC_HEADERS,
 	HEADER_ACTOR_ID,

--- a/packages/rivetkit/src/manager/driver.ts
+++ b/packages/rivetkit/src/manager/driver.ts
@@ -52,7 +52,7 @@ export interface ManagerDriver {
 
 	/**
 	 * Get or create the inspector access token.
-	 * @internal
+	 * @experimental
 	 * @returns creates or returns existing inspector access token
 	 */
 	getOrCreateInspectorAccessToken: () => string;


### PR DESCRIPTION
Fixes #1323

### TL;DR

Added `getOrCreateInspectorAccessToken` implementation to CloudflareActorsManagerDriver and exported the `generateRandomString` utility.

### What changed?

- Implemented the `getOrCreateInspectorAccessToken` method in the CloudflareActorsManagerDriver class, which returns a randomly generated string
- Imported `generateRandomString` in the manager-driver.ts file
- Exported `generateRandomString` from the driver-helpers module
- Changed the JSDoc annotation for `getOrCreateInspectorAccessToken` from `@internal` to `@experimental`

### How to test?

1. Verify that the CloudflareActorsManagerDriver correctly implements the ManagerDriver interface
2. Test that `getOrCreateInspectorAccessToken()` returns a random string when called
3. Confirm that `generateRandomString` can be imported from the driver-helpers module

### Why make this change?

This change completes the implementation of the ManagerDriver interface in the CloudflareActorsManagerDriver class by adding the missing `getOrCreateInspectorAccessToken` method. The method is marked as experimental, indicating it's available for use but the API might change in future versions. Exporting the `generateRandomString` utility makes it available for other components that need to generate random strings.